### PR TITLE
Neuen Betreuer hinzugefügt

### DIFF
--- a/_data/betreuer.yml
+++ b/_data/betreuer.yml
@@ -120,3 +120,6 @@ nk:
 
 dgaida:
   name: Prof. Dr. Daniel Gaida
+
+hvn:
+  name: Prof. Dr. Hoai Viet Nguyen


### PR DESCRIPTION
Kleine Anpassung; haben vergessen den Betreuer der entsprechenden yml-Datei anzufügen, weswegen er nicht auf der Webseite angezeigt wird